### PR TITLE
Show covers that are not fully open

### DIFF
--- a/dwains-theme/plugins/button-cards-templates/homepage/header/states/cover.yaml
+++ b/dwains-theme/plugins/button-cards-templates/homepage/header/states/cover.yaml
@@ -34,6 +34,7 @@ header_states_cover:
                   }
                   openCovers++;
                 } else {
+                  partlyClosedCovers++;                
                   closedCovers++;
                 }
               }              
@@ -48,6 +49,7 @@ header_states_cover:
                       }
                       openCovers++;                      
                     } else {
+                      partlyClosedCovers++;                    
                       closedCovers++;
                     }                  
                   }

--- a/dwains-theme/plugins/button-cards-templates/homepage/header/states/cover.yaml
+++ b/dwains-theme/plugins/button-cards-templates/homepage/header/states/cover.yaml
@@ -7,41 +7,67 @@ header_states_cover:
     action: navigate
     navigation_path: devices_covers
   name: {{ _d_t_trans.cover.title_plural }}
-  icon: "{{ _d_t_icons.cover|default('mdi:window-shutter') }}"
+  icon: >
+    [[[
+      {% if _d_t_config.global['show_covers'] in ['partly_closed','closed'] %}
+        return "{{ _d_t_icons.cover|default('mdi:window-shutter') }}"
+      {% else %}
+        return "{{ _d_t_icons.cover|default('mdi:window-shutter-open') }}"
+      {% endif %}
+    ]]]
   variables:
     status: >
       [[[
         var openCovers = 0;
-
+        var partlyClosedCovers = 0;
+        var closedCovers = 0;
+        
         {% for room in _d_t_config.rooms %}                        
           //Do some things for the covers
           {% if room["cover"] %}
             {% if room["cover"].split('.')[0] == 'cover' %}
             //This room has only 1 cover
-              if(states['{{ room["cover"] }}'] && states['{{ room["cover"] }}'].state == 'open') {
-                openCovers++;
-              }
+              if(states['{{ room["cover"] }}']) {               
+                if(states['{{ room["cover"] }}'].state == 'open'){
+                  if (states['{{ room["cover"] }}'].attributes['current_position'] != 100){
+                    partlyClosedCovers++;
+                  }
+                  openCovers++;
+                } else {
+                  closedCovers++;
+                }
+              }              
             {% elif room["cover"].split('.')[0] == 'group' %}
             //This room has group of covers
               if(states['{{ room["cover"] }}']){
                 states['{{ room["cover"] }}'].attributes['entity_id'].forEach(function(entity){
-                  if(states[entity] && states[entity].state == 'open'){
-                    openCovers++;
+                  if(states[entity]){
+                    if (states[entity].state == 'open'){                  
+                      if(states[entity].attributes['current_position'] != 100){
+                        partlyClosedCovers++;
+                      }
+                      openCovers++;                      
+                    } else {
+                      closedCovers++;
+                    }                  
                   }
                 });  
               }
             {% endif %}
           {% endif %}
         {% endfor %}
-
-        return openCovers;
+        
+        return {"open": openCovers, "partly_closed": partlyClosedCovers, "closed": closedCovers};
       ]]]
   label: >
     [[[
-      if(variables.status > 0){
-        var openCovers = variables.status;
-        return openCovers + ' ' + hass.localize('component.cover.state._.open');
-      }
+      {% if _d_t_config.global['show_covers'] == 'closed' %}
+        return variables.status['closed'] + ' ' + hass.localize('component.cover.state._.closed');
+      {% elif _d_t_config.global['show_covers'] == 'partly_closed'  %}
+        return variables.status['partly_closed'] + ' ' + hass.localize('component.cover.state._.closed');
+      {% else %}
+        return variables.status['open'] + ' ' + hass.localize('component.cover.state._.open');
+      {% endif %}        
     ]]]
   styles:
     grid:
@@ -61,7 +87,7 @@ header_states_cover:
       - width: 61px
       - display: >
           [[[
-            if(variables.status && variables.status > 0){
+            if(variables.status && variables.status['{{ _d_t_config.global["show_covers"]|default("open")}}'] > 0){
               //Open covers
               return 'block';
             } else {

--- a/dwains-theme/views/main/01.homepage.yaml
+++ b/dwains-theme/views/main/01.homepage.yaml
@@ -625,6 +625,7 @@
                                       }
                                       openCovers++;
                                     } else {
+                                      partlyClosedCovers++;                                    
                                       closedCovers++;
                                     }
                                   } 
@@ -639,6 +640,7 @@
                                           }
                                           openCovers++;                      
                                         } else {
+                                          partlyClosedCovers++;                                        
                                           closedCovers++;
                                         }                  
                                       }

--- a/dwains-theme/views/main/01.homepage.yaml
+++ b/dwains-theme/views/main/01.homepage.yaml
@@ -595,7 +595,14 @@
                       {% if devices.hasCover == true %}
                       - type: custom:button-card
                         template: homepage_device
-                        icon: "{{ _d_t_icons.cover|default('mdi:window-shutter') }}"
+                        icon: >
+                          [[[
+                            {% if _d_t_config.global['show_covers'] in ['partly_closed','closed'] %}
+                              return "{{ _d_t_icons.cover|default('mdi:window-shutter') }}"
+                            {% else %}
+                              return "{{ _d_t_icons.cover|default('mdi:window-shutter-open') }}"
+                            {% endif %}
+                          ]]]
                         name: {{ _d_t_trans.cover.title_plural }}
                         tap_action: 
                           action: navigate
@@ -603,30 +610,58 @@
                         label: >
                           [[[
                             var openCovers = 0;
+                            var partlyClosedCovers = 0;
+                            var closedCovers = 0;                            
 
                             {% for room in _d_t_config.rooms %}                        
                               //Do some things for the covers
                               {% if room["cover"] %}
                                 {% if room["cover"].split('.')[0] == 'cover' %}
                                 //This room has only 1 cover
-                                  if(states['{{ room["cover"] }}'] && states['{{ room["cover"] }}'].state == 'open') {
-                                    openCovers++;
-                                  }
+                                  if(states['{{ room["cover"] }}']) {               
+                                    if(states['{{ room["cover"] }}'].state == 'open'){
+                                      if (states['{{ room["cover"] }}'].attributes['current_position'] != 100){
+                                        partlyClosedCovers++;
+                                      }
+                                      openCovers++;
+                                    } else {
+                                      closedCovers++;
+                                    }
+                                  } 
                                 {% elif room["cover"].split('.')[0] == 'group' %}
                                 //This room has group of covers
                                   if(states['{{ room["cover"] }}']){
                                     states['{{ room["cover"] }}'].attributes['entity_id'].forEach(function(entity){
-                                      if(states[entity] && states[entity].state == 'open'){
-                                        openCovers++;
+                                      if(states[entity]){
+                                        if (states[entity].state == 'open'){                  
+                                          if(states[entity].attributes['current_position'] != 100){
+                                            partlyClosedCovers++;
+                                          }
+                                          openCovers++;                      
+                                        } else {
+                                          closedCovers++;
+                                        }                  
                                       }
                                     });  
                                   }
                                 {% endif %}
                               {% endif %}
                             {% endfor %}
+                            
+                            // set default view
+                            var viewCovers = openCovers;
+                            var viewState = 'open';
+
+                            {% if _d_t_config.global['show_covers'] == 'closed' %}
+                              viewCovers = closedCovers;
+                              viewState = 'closed';
+                            {% elif _d_t_config.global['show_covers'] == 'partly_closed'  %}
+                              viewCovers = partlyClosedCovers;
+                              viewState = 'closed';
+                            {% endif %}    
                         
-                            if(openCovers > 0){
-                              return openCovers + ' ' + hass.localize('component.cover.state._.open');
+                            if(viewCovers > 0){
+                              return viewCovers + ' ' + hass.localize('component.cover.state._.' + viewState );
                             } else {  
                               return '&nbsp;';
                             }

--- a/dwains-theme/views/main/rooms/room.yaml
+++ b/dwains-theme/views/main/rooms/room.yaml
@@ -419,7 +419,14 @@
               - type: custom:button-card
                 entity: {{ room["cover"] }}
                 template: rooms_child
-                icon: "{{ _d_t_icons.cover|default('mdi:window-shutter') }}"
+                icon: >
+                  [[[
+                    {% if _d_t_config.global['show_covers'] in ['partly_closed','closed'] %}
+                      return "{{ _d_t_icons.cover|default('mdi:window-shutter') }}"
+                    {% else %}
+                      return "{{ _d_t_icons.cover|default('mdi:window-shutter-open') }}"
+                    {% endif %}
+                  ]]]
                 tap_action: 
                   action: navigate
                   navigation_path: {{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}_cover


### PR DESCRIPTION
Fixes #158 
I'm not sure how to fix the documentation for `global.yaml`
```
Name: show_covers
Type: string
Required: No
Example: partly_closed, closed
Description: partly_closed: only show covers that have state open together with a position <100% or are closed, closed: only show covers with state closed
```