### PR TITLE
Fix to support Amazon system WebView

### DIFF
--- a/custom_components/dwains_dashboard/js/src/main.js
+++ b/custom_components/dwains_dashboard/js/src/main.js
@@ -187,7 +187,7 @@ class DwainsDashboard {
         } else {
           console.log('sun.sun not available!');
         }
-        const themes = {themes: JSON.parse(config.themes.replaceAll("placeholder_primary_color", config.primary_color))}
+        const themes = {themes: JSON.parse(config.themes.replace(/placeholder_primary_color/g, config.primary_color))}
         let theme = "dwains-theme-light";
 
         switch(config.theme) {
@@ -269,7 +269,7 @@ class DwainsDashboard {
       let popupData;
 
       if(popupData = ll.config.dwains_dashboard[domain+'_popup']){
-        cardData = JSON.parse(JSON.stringify(popupData.card).replaceAll("domain.placeholder", ev.detail.entityId));
+        cardData = JSON.parse(JSON.stringify(popupData.card).replace(/domain.placeholder/g, ev.detail.entityId));
         cardTitle = hass().states[ev.detail.entityId].attributes.friendly_name;
         customCard = true;
       }


### PR DESCRIPTION
The Dwains theme can't run properly on FireOS using system WebView (it is used in the Fully Kiosk Browser and WallPanel) because it doesn't have replaceAll function.