### PR TITLE
Adding support for smaller favorites, additional room badges and vacuum addons

### DIFF
--- a/custom_components/dwains_dashboard/installation/ignorethisfolder/global.yaml
+++ b/custom_components/dwains_dashboard/installation/ignorethisfolder/global.yaml
@@ -16,6 +16,7 @@ global:
   # inside_temperature: climate.living_room #Can be 'climate.' or an 'sensor.' entity.
 
   # favorites_homepage: 'true' #Uncomment this line if you want the house information favorites on your homepage.
+  # smaller_favorites: 'true' #Uncomment this line if you want the house information favorites in a smaller form factor
 
   # custom_popups: #Create custom popups for a whole domain. See popup addons in the docs
   #   - domain: cover

--- a/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/homepage/favorite.yaml
+++ b/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/homepage/favorite.yaml
@@ -1,0 +1,39 @@
+# dwains_dashboard
+
+homepage_favorite:
+  show_state: false
+  show_label: true
+  tap_action:
+    action: more-info
+  styles:
+    grid:
+      - grid-template-areas: '"i""n""l"'
+    icon:
+      - color: var(--dwains-theme-accent)
+      - width: 55%
+    img_cell:
+      - width: 40px
+      - height: 40px
+      - background: var(--dwains-theme-header-button-background)
+      - color: white
+      - border-radius: 100%
+    card:
+      - background: transparent
+      - box-shadow: none
+      - padding: 0%
+      - width: 61px
+    label:
+      - color: var(--dwains-theme-header-text)
+      - justify-self: center
+      - font-size: 11px
+      - line-height: 12px
+      - white-space: initial
+      - text-overflow: initial
+      - overflow: initial
+    name:
+      - color: var(--dwains-theme-header-text)
+      - justify-self: center
+      - font-size: 11px
+      - white-space: initial
+      - text-overflow: initial
+      - overflow: initial

--- a/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/homepage/header/states/vacuum.yaml
+++ b/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/homepage/header/states/vacuum.yaml
@@ -19,6 +19,15 @@ header_states_vacuum:
             if(states['{{ room["vacuum"]["entity"] }}'] && states['{{ room["vacuum"]["entity"] }}'].state != 'docked' && states['{{ room["vacuum"]["entity"] }}'].state != 'unavailable') {
               onVacuums++;
             }
+          {% else %}
+            // Check for vacuum addons
+            {% for addon in room["addons"] %}
+              {% if addon["data"]["vacuum"] %}
+                if(states['{{ addon["data"]["vacuum"] }}'] && states['{{ addon["data"]["vacuum"] }}'].state != 'docked' && states['{{ addon["data"]["vacuum"] }}'].state != 'unavailable'){
+                  onVacuums++;
+                }
+              {% endif %}
+            {% endfor %}
           {% endif %}
         {% endfor %}
 

--- a/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
@@ -125,90 +125,129 @@
                 }
             {% endif %}
             #Start header states
-            - type: custom:dwains-collapse-card
-              card_width: '62px'
+            - type: vertical-stack
               cards:
-                {% if _dd_config.persons %}
-                {% for person in _dd_config.persons %}
-                - type: custom:button-card
-                  template: header_states_person
-                  entity: {{ person["track"] }}
-                  name: {{ person["name"] }}
-                  tap_action: 
-                    action: navigate
-                    navigation_path: {{ person["name"]|lower|replace("'", "_")|replace(" ", "_")  }}
-                {% endfor %}
-                {% endif %}
-                - type: custom:button-card
-                  template: header_states_safety
-                - type: custom:button-card
-                  template: header_states_door
-                - type: custom:button-card
-                  template: header_states_window
-                - type: custom:button-card
-                  template: header_states_lock
-                - type: custom:button-card
-                  template: header_states_light
-                - type: custom:button-card
-                  template: header_states_climate
-                - type: custom:button-card
-                  template: header_states_cover
-                - type: custom:button-card
-                  template: header_states_device
-                - type: custom:button-card
-                  template: header_states_media_player
-                - type: custom:button-card
-                  template: header_states_vacuum
-                - type: custom:button-card
-                  template: header_states_plant
-                - type: custom:button-card
-                  template: header_states_vibration
-            #End header states
+                - type: custom:dwains-wrapper-card
+                  item_classes: 'col-12 col-sm-12 col-md-4 col-lg-5'
+                  css: |
+                    ha-card {
+                      margin-top: 5px;
+                    }
+                    @media only screen and (min-width: 600px) {
+                      ha-card {
+                        margin-top: 15px;
+                      }
+                    }
+                  card:
+                    type: custom:dwains-collapse-card
+                    card_width: '62px'
+                    cards:
+                      {% if _dd_config.persons %}
+                      {% for person in _dd_config.persons %}
+                      - type: custom:button-card
+                        template: header_states_person
+                        entity: {{ person["track"] }}
+                        name: {{ person["name"] }}
+                        tap_action: 
+                          action: navigate
+                          navigation_path: {{ person["name"]|lower|replace("'", "_")|replace(" ", "_")  }}
+                      {% endfor %}
+                      {% endif %}
+                      - type: custom:button-card
+                        template: header_states_safety
+                      - type: custom:button-card
+                        template: header_states_door
+                      - type: custom:button-card
+                        template: header_states_window
+                      - type: custom:button-card
+                        template: header_states_lock
+                      - type: custom:button-card
+                        template: header_states_light
+                      - type: custom:button-card
+                        template: header_states_climate
+                      - type: custom:button-card
+                        template: header_states_cover
+                      - type: custom:button-card
+                        template: header_states_device
+                      - type: custom:button-card
+                        template: header_states_media_player
+                      - type: custom:button-card
+                        template: header_states_vacuum
+                      - type: custom:button-card
+                        template: header_states_plant
+                      - type: custom:button-card
+                        template: header_states_vibration
+              #End header states
         #END HOMEPAGE HEADER
 
         #START HOMEPAGE CONTENT
         {% if _dd_config.global["favorites_homepage"] and _dd_config.global["favorites_homepage"] == 'true' %}
         #Favorites start
         {% if _dd_config.house_information and _dd_config.house_information["favorites"] %}
+        {% if _dd_config.global["smaller_favorites"] and _dd_config.global["smaller_favorites"] == 'true' %}
+                #heading  
+                - type: custom:dwains-heading-card
+                  title: {{ _dd_trans.house_information.favorites }}
+                - type: custom:dwains-wrapper-card
+                  item_classes: 'col-12 col-sm-12 col-md-4 col-lg-5'
+                  css: |
+                    ha-card {
+                      margin-top: 5px;
+                    }
+                    @media only screen and (min-width: 600px) {
+                      ha-card {
+                        margin-top: 15px;
+                      }
+                    }
+                  card:
+                    type: custom:dwains-collapse-card
+                    card_width: '62px'
+                    cards:
+        {% else %}
         - type: custom:dwains-flexbox-card
           padding: true
           items_classes: 'col-xs-12'
           cards:
-            #heading  
-            - type: custom:dwains-heading-card
-              title: {{ _dd_trans.house_information.favorites }}
-            - type: custom:dwains-flexbox-card
-              items_classes: 'col-xs-6 col-sm-6 col-md-3 col-lg-3'
-              cards:
-                #Start for house information page
-                {% for favorite in _dd_config.house_information["favorites"] %}
-                - type: custom:button-card
-                  entity: {{ favorite["entity"] }}
-                  template: more_page_house_information_favorites
-                  {% if favorite["entity"].split('.')[0] == 'input_select' %}
-                  tap_action:
-                    action: more-info
-                  double_tap_action:
-                    haptic: light
-                    action: call-service
-                    service: input_select.select_next
-                    service_data:
-                      entity_id: {{ favorite["entity"] }}
-                  {% else %}
-                  tap_action:
-                    action: more-info
-                  {% endif %}
-                  #there is a type defined so  lets change some styling and options
-                  state:
-                    {% if favorite['icon_off'] %}
-                    - value: 'off'
-                      icon: "{{ favorite['icon_off'] }}"
-                    {% endif %}
-                    {% if favorite['icon_on'] %}
-                    - value: 'on'
-                      icon: "{{ favorite['icon_on'] }}"
-                    {% endif %}
-                {% endfor %}
+                  #heading  
+                  - type: custom:dwains-heading-card
+                    title: {{ _dd_trans.house_information.favorites }}
+                  - type: custom:dwains-flexbox-card
+                    items_classes: 'col-xs-6 col-sm-6 col-md-3 col-lg-3'
+                    cards:
+        {% endif %}
+                          #Start for house information page
+                          {% for favorite in _dd_config.house_information["favorites"] %}
+                          - type: custom:button-card
+                            entity: {{ favorite["entity"] }}
+                            {% if _dd_config.global["smaller_favorites"] and _dd_config.global["smaller_favorites"] == 'true' %}
+                            template: homepage_favorite
+                            {% else %}
+                            template: more_page_house_information_favorites
+                            {% endif %}
+                            {% if favorite["entity"].split('.')[0] == 'input_select' %}
+                            tap_action:
+                              action: more-info
+                            double_tap_action:
+                              haptic: light
+                              action: call-service
+                              service: input_select.select_next
+                              service_data:
+                                entity_id: {{ favorite["entity"] }}
+                            {% else %}
+                            tap_action:
+                              action: more-info
+                            {% endif %}
+                            #there is a type defined so  lets change some styling and options
+                            state:
+                              {% if favorite['icon_off'] %}
+                              - value: 'off'
+                                icon: "{{ favorite['icon_off'] }}"
+                              {% endif %}
+                              {% if favorite['icon_on'] %}
+                              - value: 'on'
+                                icon: "{{ favorite['icon_on'] }}"
+                              {% endif %}
+                          {% endfor %}
         {% endif %}
         #Favorites end  
         {% endif %}
@@ -441,7 +480,15 @@
                                 additional_info += 'A-E!<br>';
                               }
                             {% endif %}
-
+                            {% if room["additional_badges"] %}
+                                {% for badge in room["additional_badges"] %}
+                                  {% if badge.entity.split('.')[0] == 'binary_sensor' or badge.entity.split('.')[0] == 'sensor' or badge.entity.split('.')[0] == 'input_boolean' %}
+                                    if(states['{{ badge.entity }}'].state == 'on' || states['{{ badge.entity }}'].state == 'True'){
+                                      additional_info += '<ha-icon style="height: 20px; color: var(--dwains-theme-accent)" icon="{{badge.icon|default('mdi:leak') }}"></ha-icon><br>';
+                                    }
+                                  {% endif %}
+                                {% endfor %}
+                            {% endif %}
                             return additional_info;
                           ]]]
                         {% if room["light"] %}
@@ -532,6 +579,11 @@
                         {% if room["vibration"] %}
                             {% set devices.hasVibration = true %}
                         {% endif %}
+                        {% for addon in room["addons"] %}
+                          {% if addon["data"]["vacuum"] %}
+                            {% set devices.hasVacuum = true %}
+                          {% endif %}
+                        {% endfor %}
                     {% endfor %}
 
                     {% if devices.hasLock == true %}
@@ -1028,6 +1080,15 @@
                               //This room has group of vacuums
                               //Not yet supported
                               {% endif %}
+                            {% else %}
+                              // Check for vacuum addons
+                              {% for addon in room["addons"] %}
+                                {% if addon["data"]["vacuum"] %}
+                                  if(states['{{ addon["data"]["vacuum"] }}'] && states['{{ addon["data"]["vacuum"] }}'].state != 'docked' && states['{{ addon["data"]["vacuum"] }}'].state != 'unavailable'){
+                                    onVacuums++;
+                                  }
+                                {% endif %}
+                              {% endfor %}
                             {% endif %}
                           {% endfor %}
 

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/vacuum.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/vacuum.yaml
@@ -66,5 +66,25 @@
                     type: custom:dwains-flexbox-card
                     items_classes: 'col-xs-6 col-sm-6 col-md-6 col-lg-6'
                 {% endif %}
+            {% else %}
+              {% for addon in room["addons"] %}
+                {% if addon["data"]["vacuum"] %}
+                - type: vertical-stack
+                  cards:
+                    #Heading
+                    - type: custom:dwains-heading-card
+                      title: {{ room["name"] }}
+                    - type: horizontal-stack
+                      cards:
+                        - type: custom:button-card
+                          template: room_vacuum
+                          entity: {{ addon["data"]["vacuum"] }}
+                          tap_action:
+                            action: navigate
+                            navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}_addon_{{ addon["name"]|lower|replace("'", "_")|replace(" ", "_") }}
+                          hold_action:
+                              action: more-info
+                {% endif %}
+              {% endfor %}
             {% endif %}
             {% endfor %}


### PR DESCRIPTION
I'd like to bring in some functional and UI updates that I've been using. There are three new changes introduced in this PR.

1. Smaller favorites
I wanted a way to have favorites on my homepage for easy status or script calling, but on my wall mounted tablets, the current icons take up a ton of space and end up hiding the rooms. This change introduces a user selectable alternate. The icons sit just under the header icons with a smaller form factor.
Normal:
![image](https://user-images.githubusercontent.com/7741277/146490042-4dda0e29-d9bc-4c19-951e-dfda9cc220f6.png)
Smaller:
![image](https://user-images.githubusercontent.com/7741277/146490147-bbdf1c49-cca5-4674-9228-5881b9bf1235.png)
2. Additional room badges
This change allows users to see the state of custom sensors/devices that aren't defined in the dashboard. You can give a list of binary_sensors, sensors or input_booleans that report "True" or "on" and an icon to display when it is on. My use case was I wanted to be able to at a glance see if a bed is occupied. To demonstrate, I've added a dummy input bool and set it to true.
```
rooms:
  - name: Master Bedroom
    additional_badges:
      - entity: input_boolean.dummy1
        icon: mdi:dumbbell
```
![image](https://user-images.githubusercontent.com/7741277/146490004-2a5c5166-4766-4945-88f0-6dd54a5b688c.png)

3. Vacuum Addon support
This one is more of a quality of life change. I have been using an addon page for my vaccum that adds a bit more functionality, however if the vacuum is not defined in the room and is running, it won't show up in the active devices header or in the devices tab, only the room page. If I wanted to see the status of the vacuum in the header, I needed to define the vacuum in the room, but then this led me to seeing two instances of it; one for the room and one for the room addon. As you can see in the config below, the vacuum is coming from the addon and not the room config.
Devices View:
![image](https://user-images.githubusercontent.com/7741277/146490350-aeab4aef-10a0-44ce-9363-10e9e3da9b70.png)
Room config:
```
  - name: Foyer
    icon: mdi:floor-plan
    light: light.foyer_lights
    temperature: sensor.foyer_aqara_temperature
    humidity: sensor.foyer_aqara_humidity
    pressure: sensor.foyer_aqara_pressure
    motion: binary_sensor.foyer_motion
    door: binary_sensor.front_and_garage_doors
    device: switch.magicmirror
    media_player: media_player.echo_flex_hallway
    page_entities:
      entities:
        - entity: input_boolean.foyer_motion
    addons:
      - name: Dwayne
        icon: mdi:robot-vacuum
        path: 'dwains-dashboard/addons/rooms/foyer/vacuum/page.yaml'
        button_path: 'dwains-dashboard/addons/rooms/foyer/vacuum/button.yaml'
        data:
          vacuum: vacuum.robot
          platform: valetudo
          map: camera.map_data
          rooms:
            - room: Living Room
              zone: clean_living_room
              icon: fal:couch
            - room: Kitchen
              zone: clean_kitchen
              icon: fal:refrigerator
            - room: Dining Room
              zone: clean_dining_room
              icon: fal:coffee
            - room: Hallway
              zone: clean_hall
              icon: fal:key-skeleton
            - room: Foyer
              zone: clean_foyer
              icon: fal:warehouse
            - room: Mop
              zone: clean_mop
              icon: mdi:water
          controls:
            - name: Start
              service: vacuum.start
              icon: mdi:play
            - name: Pause
              service: vacuum.pause
              icon: mdi:pause
            - name: Stop
              service: vacuum.stop
              icon: mdi:stop
            - name: Return
              service: vacuum.return_to_base
              icon: mdi:ev-station
            - name: Locate
              service: vacuum.locate
              icon: mdi:map-marker-circle
          sensors:
            - name: Main brush
              sensor: sensor.main_brush
              icon: mdi:broom
            - name: Side brush
              sensor: sensor.right_brush
              icon: mdi:broom
            - name: Filter
              sensor: sensor.main_filter
              icon: mdi:broom
            - name: Sensor
              sensor: sensor.sensor_cleaning
              icon: mdi:air-filter
```