### PR TITLE
Favourites customisation

### DIFF
--- a/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
@@ -198,41 +198,41 @@
                   tap_action:
                     action: more-info
                   {% endif %}
-                    {% if favorite['label_entity'] %}
-                    show_last_changed: false
-                    label: >
-                      [[[
-                        if (states['{{ favorite["label_entity"] }}']) {
-                            var str = states['{{ favorite["label_entity"] }}'].state;
-                            var unit = states['{{ favorite["label_entity"] }}'].attributes.unit_of_measurement;
-                            if (unit) 
-                                str += " " + unit;
-                            return str;    
-                        } else {
-                            return "N-A";
-                        }
-                      ]]]
-                    {% endif %}
-                    #there is a type defined so  lets change some styling and options
-                    state:
-                      {% if favorite['icons'] %}
-                      {% for entry in favorite['icons'] %}
-                      - operator: template
-                        value: >
-                          [[[
-                            return states['{{ entry["entity"] }}'] 
-                            && (states['{{ entry["entity"] }}'].state == '{{ entry["value"]|default("on") }}')
-                          ]]]
-                        {% if entry['icon'] %}
-                        icon: "{{ entry['icon'] }}"
-                        {% endif %}
-                        {% if entry['color'] %}
-                        styles:
-                          icon:
-                            - color: "{{ entry['color'] }}"
-                        {% endif %}
-                      {% endfor %}
+                  {% if favorite['label_entity'] %}
+                  show_last_changed: false
+                  label: >
+                    [[[
+                      if (states['{{ favorite["label_entity"] }}']) {
+                          var str = states['{{ favorite["label_entity"] }}'].state;
+                          var unit = states['{{ favorite["label_entity"] }}'].attributes.unit_of_measurement;
+                          if (unit) 
+                              str += " " + unit;
+                          return str;    
+                      } else {
+                          return "N-A";
+                      }
+                    ]]]
+                  {% endif %}
+                  #there is a type defined so  lets change some styling and options
+                  state:
+                    {% if favorite['icons'] %}
+                    {% for entry in favorite['icons'] %}
+                    - operator: template
+                      value: >
+                        [[[
+                          return states['{{ entry["entity"] }}'] 
+                          && (states['{{ entry["entity"] }}'].state == '{{ entry["value"]|default("on") }}')
+                        ]]]
+                      {% if entry['icon'] %}
+                      icon: "{{ entry['icon'] }}"
                       {% endif %}
+                      {% if entry['color'] %}
+                      styles:
+                        icon:
+                          - color: "{{ entry['color'] }}"
+                      {% endif %}
+                    {% endfor %}
+                    {% endif %}
                     {% if favorite['icon_off'] %}
                     - value: 'off'
                       icon: "{{ favorite['icon_off'] }}"

--- a/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
@@ -198,8 +198,41 @@
                   tap_action:
                     action: more-info
                   {% endif %}
-                  #there is a type defined so  lets change some styling and options
-                  state:
+                    {% if favorite['label_entity'] %}
+                    show_last_changed: false
+                    label: >
+                      [[[
+                        if (states['{{ favorite["label_entity"] }}']) {
+                            var str = states['{{ favorite["label_entity"] }}'].state;
+                            var unit = states['{{ favorite["label_entity"] }}'].attributes.unit_of_measurement;
+                            if (unit) 
+                                str += " " + unit;
+                            return str;    
+                        } else {
+                            return "N-A";
+                        }
+                      ]]]
+                    {% endif %}
+                    #there is a type defined so  lets change some styling and options
+                    state:
+                      {% if favorite['icons'] %}
+                      {% for entry in favorite['icons'] %}
+                      - operator: template
+                        value: >
+                          [[[
+                            return states['{{ entry["entity"] }}'] 
+                            && (states['{{ entry["entity"] }}'].state == '{{ entry["value"]|default("on") }}')
+                          ]]]
+                        {% if entry['icon'] %}
+                        icon: "{{ entry['icon'] }}"
+                        {% endif %}
+                        {% if entry['color'] %}
+                        styles:
+                          icon:
+                            - color: "{{ entry['color'] }}"
+                        {% endif %}
+                      {% endfor %}
+                      {% endif %}
                     {% if favorite['icon_off'] %}
                     - value: 'off'
                       icon: "{{ favorite['icon_off'] }}"

--- a/custom_components/dwains_dashboard/lovelace/views/main/more_page/house_information.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/more_page/house_information.yaml
@@ -47,41 +47,41 @@
                   tap_action:
                     action: more-info
                   {% endif %}
-                    {% if favorite['label_entity'] %}
-                    show_last_changed: false
-                    label: >
-                      [[[
-                        if (states['{{ favorite["label_entity"] }}']) {
-                            var str = states['{{ favorite["label_entity"] }}'].state;
-                            var unit = states['{{ favorite["label_entity"] }}'].attributes.unit_of_measurement;
-                            if (unit) 
-                                str += " " + unit;
-                            return str;    
-                        } else {
-                            return "N-A";
-                        }
-                      ]]]
-                    {% endif %}
-                    #there is a type defined so  lets change some styling and options
-                    state:
-                      {% if favorite['icons'] %}
-                      {% for entry in favorite['icons'] %}
-                      - operator: template
-                        value: >
-                          [[[
-                            return states['{{ entry["entity"] }}'] 
-                            && (states['{{ entry["entity"] }}'].state == '{{ entry["value"]|default("on") }}')
-                          ]]]
-                        {% if entry['icon'] %}
-                        icon: "{{ entry['icon'] }}"
-                        {% endif %}
-                        {% if entry['color'] %}
-                        styles:
-                          icon:
-                            - color: "{{ entry['color'] }}"
-                        {% endif %}
-                      {% endfor %}
+                  {% if favorite['label_entity'] %}
+                  show_last_changed: false
+                  label: >
+                    [[[
+                      if (states['{{ favorite["label_entity"] }}']) {
+                          var str = states['{{ favorite["label_entity"] }}'].state;
+                          var unit = states['{{ favorite["label_entity"] }}'].attributes.unit_of_measurement;
+                          if (unit) 
+                              str += " " + unit;
+                          return str;    
+                      } else {
+                          return "N-A";
+                      }
+                    ]]]
+                  {% endif %}
+                  #there is a type defined so  lets change some styling and options
+                  state:
+                    {% if favorite['icons'] %}
+                    {% for entry in favorite['icons'] %}
+                    - operator: template
+                      value: >
+                        [[[
+                          return states['{{ entry["entity"] }}'] 
+                          && (states['{{ entry["entity"] }}'].state == '{{ entry["value"]|default("on") }}')
+                        ]]]
+                      {% if entry['icon'] %}
+                      icon: "{{ entry['icon'] }}"
                       {% endif %}
+                      {% if entry['color'] %}
+                      styles:
+                        icon:
+                          - color: "{{ entry['color'] }}"
+                      {% endif %}
+                    {% endfor %}
+                    {% endif %}
                     {% if favorite['icon_off'] %}
                     - value: 'off'
                       icon: "{{ favorite['icon_off'] }}"

--- a/custom_components/dwains_dashboard/lovelace/views/main/more_page/house_information.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/more_page/house_information.yaml
@@ -47,8 +47,41 @@
                   tap_action:
                     action: more-info
                   {% endif %}
-                  #there is a type defined so  lets change some styling and options
-                  state:
+                    {% if favorite['label_entity'] %}
+                    show_last_changed: false
+                    label: >
+                      [[[
+                        if (states['{{ favorite["label_entity"] }}']) {
+                            var str = states['{{ favorite["label_entity"] }}'].state;
+                            var unit = states['{{ favorite["label_entity"] }}'].attributes.unit_of_measurement;
+                            if (unit) 
+                                str += " " + unit;
+                            return str;    
+                        } else {
+                            return "N-A";
+                        }
+                      ]]]
+                    {% endif %}
+                    #there is a type defined so  lets change some styling and options
+                    state:
+                      {% if favorite['icons'] %}
+                      {% for entry in favorite['icons'] %}
+                      - operator: template
+                        value: >
+                          [[[
+                            return states['{{ entry["entity"] }}'] 
+                            && (states['{{ entry["entity"] }}'].state == '{{ entry["value"]|default("on") }}')
+                          ]]]
+                        {% if entry['icon'] %}
+                        icon: "{{ entry['icon'] }}"
+                        {% endif %}
+                        {% if entry['color'] %}
+                        styles:
+                          icon:
+                            - color: "{{ entry['color'] }}"
+                        {% endif %}
+                      {% endfor %}
+                      {% endif %}
                     {% if favorite['icon_off'] %}
                     - value: 'off'
                       icon: "{{ favorite['icon_off'] }}"


### PR DESCRIPTION
Hi!

I have been using dwains-lovelace for more than a year now. I like it a lot, but initially I was struggling to get more info on the main screen. With some simple and minor tweaks I was able to put more info on it. In order to avoid merging every release and to share it with other I am making this MR.
Basically there are 2 new features:
- ability to override "last changed label"
- ability to override icon and its colour depending on a state

e.g. use-case:
- PV solar production is updated every 3 seconds, I do now want to see "Just updated" or "Updated 3 seconds ago"; instead daily production is shown
- if icon next to the PV production is coloured yellow, I have surplus PV power
- icon next to heat-pump state can indicate "heating is on, defrost mode, cooling mode, etc."

Screenshot attached:
<img width="1069" alt="Screenshot 2021-12-21 at 16 55 21" src="https://user-images.githubusercontent.com/3854164/146962269-fc85782f-41b0-49a9-af48-fd97a46fe018.png">

