### PR TITLE
Allow garage doors to show as an open door

### DIFF
--- a/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/homepage/header/states/door.yaml
+++ b/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/homepage/header/states/door.yaml
@@ -18,7 +18,7 @@ header_states_door:
           {% if room["door"] %}
             {% if room["door"].split('.')[0] == 'binary_sensor' or room["door"].split('.')[0] == 'sensor' %}
             //This room has only 1 door
-              if(states['{{ room["door"] }}'] && states['{{ room["door"] }}'].state == 'on' ||
+              if(states['{{ room["door"] }}'] && states['{{ room["door"] }}'].state == 'on' || states['{{ room["door"] }}'] && states['{{ room["door"] }}'].state == 'open' ||
                     states['{{ room["door"] }}'] && states['{{ room["door"] }}'].state == 'True') {
                 openDoors++;
               }
@@ -26,7 +26,7 @@ header_states_door:
             //This room has group of doors
               if(states['{{ room["door"] }}']){
                 states['{{ room["door"] }}'].attributes['entity_id'].forEach(function(entity){
-                  if(states[entity] && states[entity].state == 'True' || states[entity] && states[entity].state == 'on'){
+                  if(states[entity] && states[entity].state == 'True' || states[entity] && states[entity].state == 'open' || states[entity] && states[entity].state == 'on'){
                     openDoors++;
                   }
                 });  

--- a/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/homepage/header/states/door.yaml
+++ b/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/homepage/header/states/door.yaml
@@ -16,7 +16,7 @@ header_states_door:
         {% for room in _dd_config.rooms %}                        
           //Do some things for the doors
           {% if room["door"] %}
-            {% if room["door"].split('.')[0] == 'binary_sensor' or room["door"].split('.')[0] == 'sensor' %}
+            {% if room["door"].split('.')[0] == 'binary_sensor' or room["door"].split('.')[0] == 'cover' or room["door"].split('.')[0] == 'sensor' %}
             //This room has only 1 door
               if(states['{{ room["door"] }}'] && states['{{ room["door"] }}'].state == 'on' || states['{{ room["door"] }}'] && states['{{ room["door"] }}'].state == 'open' ||
                     states['{{ room["door"] }}'] && states['{{ room["door"] }}'].state == 'True') {

--- a/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/homepage/header/states/water_leak.yaml
+++ b/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/homepage/header/states/water_leak.yaml
@@ -1,0 +1,79 @@
+# dwains_dashboard
+
+header_states_water_leak:
+  show_state: false
+  show_label: true
+  tap_action: 
+    action: navigate
+    navigation_path: devices_water_leak
+  name: {{ _dd_trans.water_leak.title_plural }}
+  icon: "{{ _dd_icons.water_leak|default('mdi:water-alert') }}"
+  variables:
+    status: >
+      [[[
+        var waterLeakOn = 0;
+        {% for room in _dd_config.rooms %}
+          //Do some things for the water leak sensors
+          {% if room["water_leak"] %}
+            {% if room["water_leak"].split('.')[0] != 'group' %}
+            //This room has only 1 water leak sensor
+              if(states['{{ room["water_leak"] }}'] && states['{{ room["water_leak"] }}'].state == 'on') {
+                waterLeakOn++;
+              }
+            {% else %}
+            //This room has group of water_leak sensors
+              if(states['{{ room["water_leak"] }}']){
+                states['{{ room["water_leak"] }}'].attributes['entity_id'].forEach(function(entity){
+                  if(states[entity] && states[entity].state == 'on'){
+                    waterLeakOn++;
+                  }
+                });  
+              }
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+        return waterLeakOn;
+      ]]]
+  label: >
+    [[[
+      if(variables.status > 0){
+        var waterLeakOn = variables.status;
+        return waterLeakOn + ' ' + hass.localize('component.binary_sensor.state.moisture.on');
+      }
+    ]]]
+  styles:
+    grid:
+      - grid-template-areas: '"i""n""l"'
+    icon:
+      - color: white
+      - width: 55%
+    img_cell:
+      - width: 40px
+      - height: 40px
+      - background: var(--dwains-theme-header-button-background)
+      - color: white
+      - border-radius: 100%
+    card:
+      - background: transparent
+      - box-shadow: none
+      - padding: 0%
+      - width: 61px
+      - display: >
+          [[[
+            if(variables.status && variables.status > 0){
+              //Water leak sensors On
+              return 'block';
+            } else {
+              //No water leak sensors On
+              return 'none';
+            }
+          ]]]
+    label:
+      - color: var(--dwains-theme-header-text)
+      - justify-self: center
+      - font-size: 11px
+      - line-height: 12px
+    name:
+      - color: var(--dwains-theme-header-text)
+      - justify-self: center
+      - font-size: 13px

--- a/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/rooms/room/water_leak.yaml
+++ b/custom_components/dwains_dashboard/lovelace/plugins/button-cards-templates/rooms/room/water_leak.yaml
@@ -1,0 +1,42 @@
+room_water_leak:
+  show_name: true
+  show_icon: true
+  show_state: true
+  show_label: false
+  show_last_changed: true
+  color: 'auto'
+  styles:
+    grid:
+      - grid-template-areas: '"i n""i s""i l"'
+      - grid-template-columns: 30% 70%
+      - grid-template-rows: min-content
+    card:
+      - background-color: var(--dwains-theme-primary)
+      - border-radius: 5px
+      - margin-bottom: 0px
+      - padding-top: 14px
+      - padding-bottom: 14px
+    icon:
+      - width: 55%
+    img_cell:
+      - width: 45px
+      - height: 45px
+      - border-radius: 100%
+    name:
+      - color: var(--dwains-theme-names)
+      - justify-self: start
+      - font-size: 15px
+      - align-self: center
+    state:
+      - justify-self: start
+      - align-self: left
+      - font-size: 13px
+      - color: var(--dwains-theme-grey)
+    label:
+      - justify-self: start
+      - align-self: left
+      - font-size: 12px
+      - color: var(--dwains-theme-grey)
+  double_tap_action:
+    action: more-info
+    haptic: heavy

--- a/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
@@ -360,13 +360,13 @@
                             {% if room["door"] %}
                               if(states['{{ room["door"] }}']){
                                 {% if room["door"].split('.')[0] == 'binary_sensor' or room["door"].split('.')[0] == 'sensor' %}
-                                  if(states['{{ room["door"] }}'].state == 'on' || states['{{ room["door"] }}'].state == 'True'){
+                                  if(states['{{ room["door"] }}'].state == 'on' || states['{{ room["door"] }}'].state == 'open' || states['{{ room["door"] }}'].state == 'True'){
                                     additional_info += '<ha-icon style="height: 20px; color: var(--dwains-theme-accent)" icon="{{ _dd_icons.door_open|default('mdi:door-open') }}"></ha-icon><br>';
                                   }
                                 {% else %}
                                   const entitiesFromGroup = states['{{ room["door"] }}'].attributes['entity_id'];
                                   for (let i = 0; i < entitiesFromGroup.length; i++) {
-                                    if(states[entitiesFromGroup[i]] && states[entitiesFromGroup[i]].state == 'on' ||
+                                    if(states[entitiesFromGroup[i]] && states[entitiesFromGroup[i]].state == 'on' || states[entitiesFromGroup[i]] && states[entitiesFromGroup[i]].state == 'open' ||
                                         states[entitiesFromGroup[i]] && states[entitiesFromGroup[i]].state == 'True') {
                                       additional_info += '<ha-icon style="height: 20px; color: var(--dwains-theme-accent)" icon="{{ _dd_icons.door_open|default('mdi:door-open') }}"></ha-icon><br>';
                                       break;

--- a/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
@@ -359,7 +359,7 @@
                             {% endif %}
                             {% if room["door"] %}
                               if(states['{{ room["door"] }}']){
-                                {% if room["door"].split('.')[0] == 'binary_sensor' or room["door"].split('.')[0] == 'sensor' %}
+                                {% if room["door"].split('.')[0] == 'binary_sensor' or room["door"].split('.')[0] == 'cover' or room["door"].split('.')[0] == 'sensor' %}
                                   if(states['{{ room["door"] }}'].state == 'on' || states['{{ room["door"] }}'].state == 'open' || states['{{ room["door"] }}'].state == 'True'){
                                     additional_info += '<ha-icon style="height: 20px; color: var(--dwains-theme-accent)" icon="{{ _dd_icons.door_open|default('mdi:door-open') }}"></ha-icon><br>';
                                   }

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/water_leak.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/water_leak.yaml
@@ -1,0 +1,78 @@
+# dwains_dashboard
+
+#House all water leak sensors
+- title: {{ _dd_trans.water_leak.title_plural }}
+  path: devices_water_leak
+  panel: true
+  visible: false
+  cards:    
+    - type: custom:dwains-wrapper-card
+      css: | 
+        max-width: 1465px;
+        padding-bottom: 50px;
+        margin: 0 auto;
+        font-family: "Open Sans", sans-serif !important;
+      card:
+        type: vertical-stack
+        cards:
+          #Header
+          - type: custom:dwains-header-card
+            title:  {{ _dd_trans.water_leak.title_plural }}
+            subtitle: {{ _dd_trans.home.title }}
+            navigation_path: home#devices
+            icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
+          #Start for room water leak sensors content page
+          - type: custom:dwains-flexbox-card
+            padding: true
+            items_classes: 'col-xs-12 col-sm-6 col-md-3 col-lg-3'
+            cards:
+              {% for room in _dd_config.rooms %}
+              {% if room["water_leak"] %}
+              - type: vertical-stack
+                cards:
+                  #Heading
+                  - type: custom:dwains-heading-card
+                    title: {{ room["name"] }}
+                  {% if room["water_leak"].split('.')[0] != 'group' %}
+                  # this room has only 1 water leak sensor
+                  - type: horizontal-stack
+                    cards:
+                      - type: custom:button-card
+                        template: room_water_leak
+                        entity: {{ room["water_leak"] }}
+                        tap_action:
+                          action: more-info
+                        icon: >
+                          [[[
+                            if(entity.state == 'on')
+                              return "{{ _dd_icons.water_leak_on|default('mdi:water-alert') }}";
+                            else if(entity.state == 'off')
+                              return "{{ _dd_icons.water_leak_off|default('mdi:water-off-outline') }}";
+                          ]]]
+                  {% else %}
+                  # this room has group of water leak sensors
+                  - type: custom:dwains-auto-entities-card
+                    filter:
+                      include:
+                        - group: {{ room["water_leak"] }}
+                          options:
+                            type: custom:button-card
+                            template: room_water_leak
+                            tap_action:
+                              action: more-info
+                            icon: >
+                              [[[
+                                if(entity.state == 'on')
+                                  return "{{ _dd_icons.water_leak_on|default('mdi:water-alert') }}";
+                                else if(entity.state == 'off')
+                                  return "{{ _dd_icons.water_leak_off|default('mdi:water-0ff-outline') }}";
+                              ]]]
+                    sort:
+                      method: name
+                      ignore_case: true
+                    card:
+                      type: custom:dwains-flexbox-card
+                      items_classes: 'col-xs-6 col-sm-6 col-md-6 col-lg-6'
+                  {% endif %}
+              {% endif %}
+              {% endfor %}

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room.yaml
@@ -113,9 +113,9 @@
               label: >
                 [[[ 
                   if(entity){
-                    if(entity.state == 'off' || entity.state == 'False'){
+                    if(entity.state == 'off' || entity.state == 'closed' || entity.state == 'False'){
                       return hass.localize('component.binary_sensor.state.door.off');
-                    } else if(entity.state == 'on' || entity.state == 'True') {
+                    } else if(entity.state == 'on' || entity.state == 'open' || entity.state == 'True') {
                       return hass.localize('component.binary_sensor.state.door.on');
                     } else {
                       return entity.state;
@@ -134,7 +134,7 @@
                     const entitiesFromGroup = states['{{ room["door"] }}'].attributes['entity_id'];
                     var openDoors = 0;
                     entitiesFromGroup.forEach(function(entity){
-                      if(states[entity] && states[entity].state == 'on' || states[entity] && states[entity].state == 'True'){
+                      if(states[entity] && states[entity].state == 'on' || states[entity] && states[entity].state == 'open' || states[entity] && states[entity].state == 'True'){
                         openDoors++;
                       }
                     });  

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/water_leak.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/water_leak.yaml
@@ -1,0 +1,57 @@
+# dwains_dashboard
+
+#Page for water leak of a room
+
+{% for room in _dd_config.rooms %}
+{% if room["water_leak"] %}
+- title: {{ room["name"] }} {{ _dd_trans.water_leak.title_plural }}
+  path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}_water_leak
+  panel: true
+  visible: false
+  cards:    
+    - type: custom:dwains-wrapper-card
+      css: | 
+        max-width: 1465px;
+        padding-bottom: 50px;
+        margin: 0 auto;
+        font-family: "Open Sans", sans-serif !important;
+      card:
+        type: vertical-stack
+        cards:
+          #Header
+          - type: custom:dwains-header-card
+            title:  {{ _dd_trans.water_leak.title_plural }}
+            subtitle: {{ room["name"] }}
+            navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
+            icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
+          #Start for room water leak content page
+          {% if room["water_leak"].split('.')[0] != 'group' %}
+          # this room has only 1 water leak sensor
+          {% else %}
+          # this room has group of water leak sensors
+          - type: custom:dwains-auto-entities-card
+            filter:
+              include:
+                - group: {{ room["water_leak"] }}
+                  options:
+                    type: custom:button-card
+                    template: room_water_leak
+                    hold_action:
+                      action: more-info
+                    icon: >
+                      [[[
+                        if(entity.state == 'on')
+                          return "{{ _dd_icons.water_leak_on|default('mdi:water-alert') }}";
+                        else if(entity.state == 'off')
+                          return "{{ _dd_icons.water_leak_off|default('mdi:water-off-outline') }}";
+                      ]]]
+            sort:
+              method: name
+              ignore_case: true
+            card:
+              type: custom:dwains-flexbox-card
+              padding: true
+              items_classes: 'col-xs-12 col-sm-6 col-md-3 col-lg-3'
+          {% endif %}
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
When garage doors (covers) are added as a "door", this fix will allow the door open icon to show in the header, the homepage and inside the room.