### PR TITLE
Use full page (addons page)

### DIFF
--- a/custom_components/dwains_dashboard/lovelace/views/main/04.more_page_addons.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/04.more_page_addons.yaml
@@ -29,6 +29,7 @@
             padding: 11px;
           cards:
             - type: vertical-stack
+              item_classes: "col-xs-12"
               cards:
                 !include 
                   - ../../../../../{{ addon["path"] }}


### PR DESCRIPTION
I don't know if it's just me, but when creating/adding an add-on it's directly using full screen even with a flex box. I did a clean install and the issue was still there. If this is not just me, this fixed it.