### PR TITLE
Enable non-ascii characters for titles of rooms / persons / add-ons

### DIFF
--- a/custom_components/dwains_dashboard/installation/ignorethisfolder/more_page.yaml
+++ b/custom_components/dwains_dashboard/installation/ignorethisfolder/more_page.yaml
@@ -2,7 +2,8 @@
 
 # more_page:
 #   addons:
-#     - name: Hello more page
+#     - name: hello # Has to use ascii letters only
+#       title: "Hello more page" # May contain non-ascii letters
 #       icon: mdi:chart-bar
 #       path: 'dwains-dashboard/addons/more_page/hello-more-page/page.yaml'
 #       data:

--- a/custom_components/dwains_dashboard/installation/ignorethisfolder/persons.yaml
+++ b/custom_components/dwains_dashboard/installation/ignorethisfolder/persons.yaml
@@ -1,7 +1,8 @@
 # https://dwainscheeren.github.io/dwains-lovelace-dashboard/configuration/persons.html
 
 # persons: 
-#   - name: Dwain
+#   - name: dwain # Has to use ascii letters only
+#     title: "Dwain" # May contain non-ascii letters
 #     track: person.dwain
 #     more_entities:
 #       columns: 1 #optional

--- a/custom_components/dwains_dashboard/installation/ignorethisfolder/rooms.yaml
+++ b/custom_components/dwains_dashboard/installation/ignorethisfolder/rooms.yaml
@@ -1,7 +1,8 @@
 # https://dwainscheeren.github.io/dwains-lovelace-dashboard/configuration/rooms.html
 
 # rooms:
-#   - name: Hallway
+#   - name: hallway # Has to use ascii letters only
+#     title: "Hallway" # May contain non-ascii letters
 #     icon: mdi:key
 #     light: light.hallway
 #     temperature: sensor.hallway_temperature
@@ -34,7 +35,8 @@
 #           some_data: 'This is some data parsed.'
 #           some_other_data: 'and some other data.'
 #           entity: vacuum.roborock
-#   - name: Bedroom
+#   - name: bedroom
+#     title: "Bedroom"
 #     icon: fal:bed
 #     more_entities:
 #       columns: 2 #optional

--- a/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
@@ -133,7 +133,7 @@
                 - type: custom:button-card
                   template: header_states_person
                   entity: {{ person["track"] }}
-                  name: {{ person["name"] }}
+                  name: {{ person["title"] }}
                   tap_action: 
                     action: navigate
                     navigation_path: {{ person["name"]|lower|replace("'", "_")|replace(" ", "_")  }}
@@ -252,7 +252,7 @@
                       {% if room["light"] %}
                       entity: {{ room["light"] }}
                       {% endif %}
-                      name: {{ room["name"] }}
+                      name: {{ room["title"] }}
                       {% if room["show_name"] == 'false' %}
                       show_name: false
                       {% endif %}

--- a/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/01.homepage.yaml
@@ -133,7 +133,7 @@
                 - type: custom:button-card
                   template: header_states_person
                   entity: {{ person["track"] }}
-                  name: {{ person["title"] }}
+                  name: {% if person["title"] %} {{ person["title"] }} {% else %} {{ person["name"] }} {% endif %} 
                   tap_action: 
                     action: navigate
                     navigation_path: {{ person["name"]|lower|replace("'", "_")|replace(" ", "_")  }}
@@ -252,7 +252,7 @@
                       {% if room["light"] %}
                       entity: {{ room["light"] }}
                       {% endif %}
-                      name: {{ room["title"] }}
+                      name: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                       {% if room["show_name"] == 'false' %}
                       show_name: false
                       {% endif %}

--- a/custom_components/dwains_dashboard/lovelace/views/main/02.lights.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/02.lights.yaml
@@ -129,7 +129,7 @@
                 #Heading
                 - type: custom:button-card
                   entity: {{ room["light"] }}
-                  name: {{ room["name"] }}
+                  name: {{ room["title"] }}
                   template: partials_heading
                   tap_action:
                     action: more-info

--- a/custom_components/dwains_dashboard/lovelace/views/main/02.lights.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/02.lights.yaml
@@ -129,7 +129,7 @@
                 #Heading
                 - type: custom:button-card
                   entity: {{ room["light"] }}
-                  name: {{ room["title"] }}
+                  name: {% if room["title"] is defined and room["title"] | length %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                   template: partials_heading
                   tap_action:
                     action: more-info

--- a/custom_components/dwains_dashboard/lovelace/views/main/04.more_page_addons.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/04.more_page_addons.yaml
@@ -3,7 +3,7 @@
 #More_page addon view - dwains dashboard with custom pages with more_page configuration 
 {% if _dd_config.more_page and _dd_config.more_page["addons"]%}
 {% for addon in _dd_config.more_page["addons"] %}
-- title: {{ addon["name"] }}
+- title: {{ addon["title"] }}
   path: more_page_addon_{{ addon["name"]|lower|replace("'", "_")|replace(" ", "_") }}
   type: custom:dwains-dashboard
   icon: {{ addon["icon"] }}
@@ -18,7 +18,7 @@
         {% if addon["show_header"] != 'false' %}
         #Header
         - type: custom:dwains-header-card
-          title:  {{ addon["name"] }}
+          title:  {{ addon["title"] }}
           subtitle: {{ _dd_trans.more_page.title }}
           navigation_path: more_page
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
@@ -29,7 +29,6 @@
             padding: 11px;
           cards:
             - type: vertical-stack
-              item_classes: "col-xs-12"
               cards:
                 !include 
                   - ../../../../../{{ addon["path"] }}

--- a/custom_components/dwains_dashboard/lovelace/views/main/04.more_page_addons.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/04.more_page_addons.yaml
@@ -18,7 +18,7 @@
         {% if addon["show_header"] != 'false' %}
         #Header
         - type: custom:dwains-header-card
-          title:  {{ addon["title"] }}
+          title:  {% if addon["title"] %} {{ addon["title"] }} {% else %} {{ addon["name"] }} {% endif %} 
           subtitle: {{ _dd_trans.more_page.title }}
           navigation_path: more_page
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}

--- a/custom_components/dwains_dashboard/lovelace/views/main/05.more_page.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/05.more_page.yaml
@@ -74,7 +74,7 @@
             - type: custom:button-card
               template: more_page_main
               icon: {{ more_page["icon"]|default('mdi:puzzle') }}
-              name: {{ more_page["name"] }}
+              name: {% if more_page["title"] %} {{ more_page["title"] }} {% else %} {{ more_page["name"] }} {% endif %}
               tap_action: 
                 action: navigate
                 navigation_path: more_page_addon_{{ more_page["name"]|lower|replace("'", "_")|replace(" ", "_") }}

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/climate.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/climate.yaml
@@ -26,7 +26,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["name"] }}
+                  title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                 {% if room["climate"] %}
                 {% if room["climate"].split('.')[0] == 'climate' %}
                 # this room has only 1 climate

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/covers.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/covers.yaml
@@ -24,7 +24,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["name"] }}
+                  title: {{ room["title"] }}
                 {% if room["cover"].split('.')[0] == 'cover' %}
                 # this room has only 1 cover
                 - type: custom:dwains-cover-card

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/covers.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/covers.yaml
@@ -24,7 +24,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["title"] }}
+                  title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                 {% if room["cover"].split('.')[0] == 'cover' %}
                 # this room has only 1 cover
                 - type: custom:dwains-cover-card

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/devices.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/devices.yaml
@@ -26,7 +26,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["name"] }}
+                  title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                 {% if room["device"].split('.')[0] != 'group' %}
                 # this room has only 1 device
                 - type: horizontal-stack

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/doors.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/doors.yaml
@@ -25,7 +25,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["name"] }}
+                  title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                 {% if room["door"].split('.')[0] != 'group' %}
                 # this room has only 1 door
                 - type: horizontal-stack

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/lights.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/lights.yaml
@@ -126,7 +126,7 @@
                 #Heading
                 - type: custom:button-card
                   entity: {{ room["light"] }}
-                  name: {{ room["name"] }}
+                  name: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                   template: partials_heading
                   tap_action:
                     action: more-info

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/locks.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/locks.yaml
@@ -25,7 +25,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["name"] }}
+                  title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                 {% if room["lock"].split('.')[0] == 'lock' %}
                 # this room has only 1 lock
                 - type: horizontal-stack

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/media_players.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/media_players.yaml
@@ -25,7 +25,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["name"] }}
+                  title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                 {% if room["media_player"].split('.')[0] != 'group' %}
                 # this room has only 1 media player
                 - type: horizontal-stack

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/plants.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/plants.yaml
@@ -25,7 +25,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["name"] }}
+                  title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                 {% if room["plant"].split('.')[0] == 'plant' %}
                 # this room has only 1 plant
                 - type: horizontal-stack

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/safety.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/safety.yaml
@@ -26,7 +26,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["name"] }}
+                  title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                 {% if room["safety"].split('.')[0] != 'group' %}
                 # this room has only 1 device
                 - type: horizontal-stack

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/vacuum.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/vacuum.yaml
@@ -26,7 +26,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["name"] }}
+                  title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                 {% if room["vacuum"]["entity"].split('.')[0] != 'group' %}
                 # this room has only 1 vacuum
                 - type: horizontal-stack

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/vibration.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/vibration.yaml
@@ -26,7 +26,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["name"] }}
+                  title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                 {% if room["vibration"].split('.')[0] != 'group' %}
                 # this room has only 1 vibration sensor
                 - type: horizontal-stack

--- a/custom_components/dwains_dashboard/lovelace/views/main/devices/windows.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/devices/windows.yaml
@@ -25,7 +25,7 @@
               cards:
                 #Heading
                 - type: custom:dwains-heading-card
-                  title: {{ room["name"] }}
+                  title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
                 {% if room["window"].split('.')[0] != 'group' %}
                 # this room has only 1 window
                 - type: horizontal-stack

--- a/custom_components/dwains_dashboard/lovelace/views/main/more_page/house_information.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/more_page/house_information.yaml
@@ -67,7 +67,7 @@
               cards:
                 !include 
                   - ../../../../../../{{ addon["path"] }}
-                  - name: {{ addon["name"] }}
+                  - name: {% if addon["title"] %} {{ addon["title"] }} {% else %} {{ addon["name"] }} {% endif %} 
                     {% if addon["data"] %}
                     data: '{{ addon["data"]|tojson }}'
                     {% endif %}

--- a/custom_components/dwains_dashboard/lovelace/views/main/persons/person.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/persons/person.yaml
@@ -30,7 +30,7 @@
         {% else %}
         #Header
         - type: custom:dwains-header-card
-          title:  {{ person["name"] }}
+          title:  {% if person["title"] is defined and person["title"] | length %} {{ person["title"] }} {% else %} {{ person["name"] }} {% endif %} 
           subtitle: {{ _dd_trans.home.title }}
           navigation_path: home  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}

--- a/custom_components/dwains_dashboard/lovelace/views/main/persons/person/more_entities.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/persons/person/more_entities.yaml
@@ -4,7 +4,7 @@
 {% if _dd_config.persons %}
 {% for person in _dd_config.persons %}
 {% if person["more_entities"] %}
-- title: {{ person["name"] }} {{ _dd_trans.more_entities.title }}
+- title: {% if person["title"] is defined and person["title"] | length %} {{ person["title"] }} {% else %} {{ person["name"] }} {% endif %} {{ _dd_trans.more_entities.title }}
   path: {{ person["name"]|lower|replace("'", "_")|replace(" ", "_") }}_more_entities
   type: custom:dwains-dashboard
   visible: false
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title:  {{ _dd_trans.more_entities.title }}
-          subtitle: {{ person["name"] }}
+          subtitle: {% if person["title"] is defined and person["title"] | length %} {{ person["title"] }} {% else %} {{ person["name"] }} {% endif %} 
           navigation_path: {{ person["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for person more_entities content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room.yaml
@@ -4,7 +4,7 @@
 #First make a room page and then a page for each existing domain in that room
 
 {% for room in _dd_config.rooms %}
-- title: {{ room["title"] }}
+- title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
   path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}
   type: custom:dwains-dashboard
   visible: false
@@ -32,7 +32,7 @@
         {% else %}
         #Header
         - type: custom:dwains-header-card
-          title: {{ room["title"] }}
+          title: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           subtitle: {{ _dd_trans.home.title }}
           navigation_path: home
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room.yaml
@@ -822,7 +822,7 @@
             {% if addon["button_path"] %}
             - !include 
                 - ../../../../../../{{ addon["button_path"] }}
-                - name: {{ addon["name"] }}
+                - name: {% if addon["title"] %} {{ addon["title"] }} {% else %} {{ addon["name"] }} {% endif %} 
                   icon: {{ addon["icon"] }}
                   navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}_addon_{{ addon["name"]|lower|replace("'", "_")|replace(" ", "_") }}
                   room_name: {{ room["name"] }}
@@ -833,7 +833,7 @@
             - type: custom:button-card
               template: rooms_child
               icon: {{ addon["icon"]|default('mdi:puzzle') }}
-              name: {{ addon["name"] }}
+              name: {% if addon["title"] %} {{ addon["title"] }} {% else %} {{ addon["name"] }} {% endif %} 
               tap_action: 
                 action: navigate
                 navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}_addon_{{ addon["name"]|lower|replace("'", "_")|replace(" ", "_") }}

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room.yaml
@@ -4,7 +4,7 @@
 #First make a room page and then a page for each existing domain in that room
 
 {% for room in _dd_config.rooms %}
-- title: {{ room["name"] }}
+- title: {{ room["title"] }}
   path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}
   type: custom:dwains-dashboard
   visible: false
@@ -14,7 +14,7 @@
         {% if room["more_entities"] and room["more_entities"]["entities"] %}
         #Header with grid
         - type: custom:dwains-header-card
-          title: {{ room["name"] }}
+          title: {{ room["title"] }}
           subtitle: {{ _dd_trans.home.title }}
           navigation_path: home  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
@@ -32,7 +32,7 @@
         {% else %}
         #Header
         - type: custom:dwains-header-card
-          title: {{ room["name"] }}
+          title: {{ room["title"] }}
           subtitle: {{ _dd_trans.home.title }}
           navigation_path: home
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/addon.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/addon.yaml
@@ -15,8 +15,8 @@
         {% if addon["show_header"] != 'false' %}
         #Header
         - type: custom:dwains-header-card
-          title: {{ addon["title"] }}
-          subtitle: {{ room["title"] }}
+          title: {% if addon["title"] %} {{ addon["title"] }} {% else %} {{ addon["name"] }} {% endif %} 
+          subtitle: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         {% endif %}
@@ -29,7 +29,7 @@
               cards:
                 !include 
                   - ../../../../../../../{{ addon["path"] }}
-                  - name: {{ addon["name"] }}
+                  - name: {% if addon["title"] %} {{ addon["title"] }} {% else %} {{ addon["name"] }} {% endif %} 
                     {% if addon["data"] %}
                     data: '{{ addon["data"]|tojson }}'
                     {% endif %}

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/addon.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/addon.yaml
@@ -5,7 +5,7 @@
 {% for room in _dd_config.rooms %}
 {% if room["addons"] %}
 {% for addon in room["addons"] %}
-- title: {{ addon["name"] }}
+- title: {{ addon["title"] }}
   path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}_addon_{{ addon["name"]|lower|replace("'", "_")|replace(" ", "_") }}
   type: custom:dwains-dashboard
   visible: false
@@ -15,8 +15,8 @@
         {% if addon["show_header"] != 'false' %}
         #Header
         - type: custom:dwains-header-card
-          title: {{ addon["name"] }}
-          subtitle: {{ room["name"] }}
+          title: {{ addon["title"] }}
+          subtitle: {{ room["title"] }}
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         {% endif %}

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/climate.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/climate.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title: {{ _dd_trans.climate.title }}
-          subtitle: {{ room["title"] }}
+          subtitle: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room climate content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/climate.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/climate.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title: {{ _dd_trans.climate.title }}
-          subtitle: {{ room["name"] }}
+          subtitle: {{ room["title"] }}
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room climate content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/devices.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/devices.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title:  {{ _dd_trans.device.title_plural }}
-          subtitle: {{ room["title"] }}
+          subtitle: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room devices content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/devices.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/devices.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title:  {{ _dd_trans.device.title_plural }}
-          subtitle: {{ room["name"] }}
+          subtitle: {{ room["title"] }}
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room devices content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/lights.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/lights.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title:  {{ _dd_trans.light.title_plural }}
-          subtitle: {{ room["name"] }}
+          subtitle: {{ room["title"] }}
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room lights content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/lights.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/lights.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title:  {{ _dd_trans.light.title_plural }}
-          subtitle: {{ room["title"] }}
+          subtitle: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room lights content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/locks.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/locks.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title: {{ _dd_trans.lock.title_plural }}
-          subtitle: {{ room["name"] }}
+          subtitle: {{ room["title"] }}
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         {% if room["lock"].split('.')[0] == 'lock' %}

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/locks.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/locks.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title: {{ _dd_trans.lock.title_plural }}
-          subtitle: {{ room["title"] }}
+          subtitle: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         {% if room["lock"].split('.')[0] == 'lock' %}

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/media_players.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/media_players.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title: {{ _dd_trans.media_player.title_plural }}
-          subtitle: {{ room["name"] }}
+          subtitle: {{ room["title"] }}
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room media_players content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/media_players.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/media_players.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title: {{ _dd_trans.media_player.title_plural }}
-          subtitle: {{ room["title"] }}
+          subtitle: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room media_players content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/more_entities.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/more_entities.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title: {{ _dd_trans.more_entities.title }}
-          subtitle: {{ room["name"] }}
+          subtitle: {{ room["title"] }}
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room more_entities content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/more_entities.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/more_entities.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title: {{ _dd_trans.more_entities.title }}
-          subtitle: {{ room["title"] }}
+          subtitle: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room more_entities content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/plants.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/plants.yaml
@@ -13,7 +13,7 @@
         #Header
         - type: custom:dwains-header-card
           title:  {{ _dd_trans.plant.title_plural }}
-          subtitle: {{ room["name"] }}
+          subtitle: {{ room["title"] }}
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room lights content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/plants.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/plants.yaml
@@ -13,7 +13,7 @@
         #Header
         - type: custom:dwains-header-card
           title:  {{ _dd_trans.plant.title_plural }}
-          subtitle: {{ room["title"] }}
+          subtitle: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room lights content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/safety.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/safety.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title:  {{ _dd_trans.safety.title_plural }}
-          subtitle: {{ room["title"] }}
+          subtitle: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room devices content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/safety.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/safety.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title:  {{ _dd_trans.safety.title_plural }}
-          subtitle: {{ room["name"] }}
+          subtitle: {{ room["title"] }}
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room devices content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/vacuum.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/vacuum.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title:  {{ _dd_trans.vacuum.title }}
-          subtitle: {{ room["name"] }}
+          subtitle: {{ room["title"] }}
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room vacuum content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/vacuum.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/vacuum.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title:  {{ _dd_trans.vacuum.title }}
-          subtitle: {{ room["title"] }}
+          subtitle: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room vacuum content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/vibration.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/vibration.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title: {{ _dd_trans.vibration.title_plural }}
-          subtitle: {{ room["name"] }}
+          subtitle: {{ room["title"] }}
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room devices content page

--- a/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/vibration.yaml
+++ b/custom_components/dwains_dashboard/lovelace/views/main/rooms/room/vibration.yaml
@@ -14,7 +14,7 @@
         #Header
         - type: custom:dwains-header-card
           title: {{ _dd_trans.vibration.title_plural }}
-          subtitle: {{ room["title"] }}
+          subtitle: {% if room["title"] %} {{ room["title"] }} {% else %} {{ room["name"] }} {% endif %} 
           navigation_path: room_{{ room["name"]|lower|replace("'", "_")|replace(" ", "_") }}  
           icon: {{ _dd_icons.menu_back|default('mdi:chevron-left') }}
         #Start for room devices content page


### PR DESCRIPTION
Currently a name like "Küche" (kitchen) for a room or generally non-ascii characters in name attributes oaf rooms, persons and add-ons will generate invalid navigation paths. This PR introduces an optional attribute "title" which is used for display if set. Otherwise the established "name" attribute is used.