### PR TITLE
Make theme backgrounds work in all (most) browsers

### DIFF
--- a/custom_components/dwains_dashboard/lovelace/ui-lovelace.yaml
+++ b/custom_components/dwains_dashboard/lovelace/ui-lovelace.yaml
@@ -13,6 +13,6 @@ apexcharts_card_templates:
   !include_dir_merge_named ../../../dwains-dashboard/apexcharts_card_templates
 
 # Start of main lovelace theme 
-background: var(--background-image)
+lovelace-background: var(--background-image)
 views:
   !include_dir_merge_list views/


### PR DESCRIPTION
It seems `lovelace-background` works for firefox, chrome and safari where as `background` only worked in safari for me.