### PR TITLE
Fix missing icons in HA 2024.2

### DIFF
--- a/custom_components/dwains_dashboard/js/dwains-dashboard.js
+++ b/custom_components/dwains_dashboard/js/dwains-dashboard.js
@@ -3541,6 +3541,8 @@
                 tabindex="-1"
                 data-domain=${(0,o.N5)(e)}
                 data-state=${e.state}
+                .hass=${this.hass}
+                .stateObj=${e}
                 .state=${e}
                 .entity=${e.entity_id}
                 @click=${this._toggleEntity}
@@ -5231,6 +5233,8 @@
                 data-domain=${(0,a.N5)(e)}
                 data-state=${e.state}
                 .icon=${this._config.icon}
+                .hass=${this.hass}
+                .stateObj=${e}
                 .state=${e}
               ></ha-state-icon>
             </div>
@@ -5334,6 +5338,8 @@
             >
               <ha-state-icon
                 .icon=${this._config.icon}
+                .hass=${this.hass}
+                .stateObj=${e}
                 .state=${e}
                 style=${(0,a.V)({filter:this._computeBrightness(e),color:this._computeColor(e)})}
               ></ha-state-icon>
@@ -5410,6 +5416,8 @@
             <div class="icon cursor-pointer">
               <ha-state-icon
                 .icon=${this._config.icon}
+                .hass=${this.hass}
+                .stateObj=${e}
                 .state=${e}
               ></ha-state-icon>
             </div>
@@ -5495,6 +5503,8 @@
                 data-domain=${(0,n.N5)(e)}
                 data-state=${e.state}
                 .icon=${this._config.icon}
+                .hass=${this.hass}
+                .stateObj=${e}
                 .state=${e}
                 .entity=${this._config.entity}
                 @click=${this._toggleEntity}


### PR DESCRIPTION
Added missing `<ha-state-icon>` attributes according to this announcement: https://developers.home-assistant.io/blog/2024/01/30/ha-state-icon-properties-changes/
Keeping the backwards compatibility with the old versions of HA.

Related with issue #781.